### PR TITLE
Stabilize Android build workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,8 +1,10 @@
+---
+# yamllint disable rule:line-length
 name: Android APK
 
-on:
+'on':
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -24,8 +26,8 @@ jobs:
       - name: Export with Godot
         uses: firebelley/godot-export@v6.0.0
         with:
-          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.4.1/Godot_v4.4.1-stable_linux.x86_64.zip
-          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.4.1/Godot_v4.4.1-stable_export_templates.tpz
+          godot_executable_download_url: https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_linux.x86_64.zip
+          godot_export_templates_download_url: https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_export_templates.tpz
           relative_project_path: ./game
           presets_to_export: Android
           use_preset_export_path: true


### PR DESCRIPTION
## Summary
- fix Godot export step by downloading engine and templates from GitHub releases
- add YAML header and lint directive for workflow

## Testing
- `/tmp/godot441/Godot_v4.4.1-stable_linux.x86_64 --headless --script tools/headless_test.gd`
- `yamllint .github/workflows/android.yml`


------
https://chatgpt.com/codex/tasks/task_e_689e14133c24833196a0905718c36c13